### PR TITLE
Changed, so that no game breaking moves still applies, even if moves are not randomized

### DIFF
--- a/src/com/dabomstew/pkrandom/Randomizer.java
+++ b/src/com/dabomstew/pkrandom/Randomizer.java
@@ -247,15 +247,42 @@ public class Randomizer {
             romHandler.randomizeMovesLearnt(true, noBrokenMoves, forceFourLv1s, msGoodDamagingProb);
         } else if (settings.getMovesetsMod() == Settings.MovesetsMod.COMPLETELY_RANDOM) {
             romHandler.randomizeMovesLearnt(false, noBrokenMoves, forceFourLv1s, msGoodDamagingProb);
+        } else if (noBrokenMoves) {
+            romHandler.removeBrokenMoves();
         }
 
         if (settings.isReorderDamagingMoves()) {
             romHandler.orderDamagingMovesByDamage();
         }
 
+
         // Show the new movesets if applicable
         if (settings.getMovesetsMod() == Settings.MovesetsMod.UNCHANGED) {
-            log.println("Pokemon Movesets: Unchanged." + NEWLINE);
+            if (settings.doBlockBrokenMoves()) {
+                log.print("Pokemon Movesets: Removed Game-Breaking Moves (");
+
+                List<Integer> gameBreakingMoves = romHandler.getGameBreakingMoves();
+                int numberPrinted = 0;
+
+                for (Move move : moves) {
+                    if (move == null) {
+                        continue;
+                    }
+
+                    if (gameBreakingMoves.contains(move.number)) {
+                        numberPrinted++;
+                        log.print(move.name);
+
+                        if (numberPrinted < gameBreakingMoves.size()) {
+                            log.print(", ");
+                        }
+                    }
+                }
+
+                log.println(")" + NEWLINE);
+            } else {
+                log.println("Pokemon Movesets: Unchanged." + NEWLINE);
+            }
         } else if (settings.getMovesetsMod() == Settings.MovesetsMod.METRONOME_ONLY) {
             log.println("Pokemon Movesets: Metronome Only." + NEWLINE);
         } else {

--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -28,21 +28,7 @@ package com.dabomstew.pkrandom.romhandlers;
 /*----------------------------------------------------------------------------*/
 
 import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Random;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 
 import com.dabomstew.pkrandom.CustomNamesSet;
 import com.dabomstew.pkrandom.MiscTweak;
@@ -1624,6 +1610,19 @@ public abstract class AbstractRomHandler implements RomHandler {
             log(logStr);
         }
         logBlankLine();
+    }
+
+    @Override
+    public void removeBrokenMoves() {
+        Map<Pokemon, List<MoveLearnt>> movesets = this.getMovesLearnt();
+        Set<Integer> allBanned = new HashSet<Integer>(this.getGameBreakingMoves());
+
+        for (List<MoveLearnt> movesLearnt : movesets.values()) {
+            movesLearnt.removeIf(move -> allBanned.contains(move.move));
+        }
+
+        // Done, save
+        this.setMovesLearnt(movesets);
     }
 
     @Override

--- a/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
@@ -210,6 +210,8 @@ public interface RomHandler {
 
     public List<Integer> getMovesBannedFromLevelup();
 
+    public void removeBrokenMoves();
+
     public void randomizeMovesLearnt(boolean typeThemed, boolean noBroken, boolean forceFourStartingMoves,
             double goodDamagingProbability);
 


### PR DESCRIPTION
I thought it was strange, that "No Game-Breaking Moves" allows game breaking moves if movesets are not randomized. In gen 5, Gible learns Dragon Rage level 7, and if you get this as your start (Or early trainers have it), it breaks the game.