### PR TITLE
Update Gen5Constants.java

### DIFF
--- a/src/com/dabomstew/pkrandom/constants/Gen5Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen5Constants.java
@@ -74,7 +74,7 @@ public class Gen5Constants {
 
     public static final int waterStoneIndex = 84;
 
-    public static final int highestAbilityIndex = 123;
+    public static final int highestAbilityIndex = 164; // this used to be 123, so it only included up to Gen IV abilities 
 
     public static final int normalItemSetVarCommand = 0x28, hiddenItemSetVarCommand = 0x2A, normalItemVarSet = 0x800C,
             hiddenItemVarSet = 0x8000;


### PR DESCRIPTION
There's a bug where randomizing abilities in Pokemon Black 2 would cause Pokemon to only have up to Gen IV abilities, and it's due to the highestAbilityIndex constant being incorrect. Bulbapedia confirms the index of the last Gen V ability is 164.